### PR TITLE
Fix panics

### DIFF
--- a/truncate.go
+++ b/truncate.go
@@ -56,35 +56,41 @@ func (e EllipsisMiddleStrategy) Truncate(str string, length int) string {
 
 // Truncate truncates string according the parameters
 func Truncate(str string, length int, omission string, pos TruncatePosition) string {
+	if length < 1 {
+		return ""
+	}
 	r := []rune(str)
 	sLen := len(r)
+	oLen := utf8.RuneCountInString(omission)
 	if length >= sLen {
 		return str
 	}
+	if length <= oLen {
+		return truncateEnd(r, length, "", 0)
+	}
 	switch pos {
 	case PositionStart:
-		return truncateStart(r, length, omission)
+		return truncateStart(r, length, omission, oLen)
 	case PositionMiddle:
-		return truncateMiddle(r, length, omission)
+		return truncateMiddle(r, length, omission, oLen)
 	default:
-		return truncateEnd(r, length, omission)
+		return truncateEnd(r, length, omission, oLen)
 	}
 }
 
-func truncateStart(r []rune, length int, omission string) string {
-	return string(omission + string(r[len(r)-length+utf8.RuneCountInString(omission):]))
+func truncateStart(r []rune, length int, omission string, oLen int) string {
+	return string(omission + string(r[len(r)-length+oLen:]))
 }
 
-func truncateEnd(r []rune, length int, omission string) string {
-	return string(string(r[:length-utf8.RuneCountInString(omission)]) + omission)
+func truncateEnd(r []rune, length int, omission string, oLen int) string {
+	return string(string(r[:length-oLen]) + omission)
 }
 
-func truncateMiddle(r []rune, length int, omission string) string {
+func truncateMiddle(r []rune, length int, omission string, oLen int) string {
 	sLen := len(r)
-	oLen := utf8.RuneCountInString(omission)
 	// Make sure we have one character before and after
 	if length < oLen+2 {
-		return truncateEnd(r, length, "")
+		return truncateEnd(r, length, "", oLen)
 	}
 	var delta int
 	if sLen%2 == 0 {

--- a/truncate_test.go
+++ b/truncate_test.go
@@ -85,6 +85,57 @@ func TestTruncator(t *testing.T) {
 	}
 }
 
+func TestTruncate(t *testing.T) {
+	type args struct {
+		str      string
+		length   int
+		omission string
+		pos      TruncatePosition
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			"omission shorter than length",
+			args{"test string", 2, "...", PositionEnd},
+			"te",
+		},
+		{
+			"negative length",
+			args{"test string", -2, "...", PositionEnd},
+			"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("Truncate should not panic with `%v`", r)
+				}
+			}()
+
+			if got := Truncate(tt.args.str, tt.args.length, tt.args.omission, tt.args.pos); got != tt.want {
+				t.Errorf("Truncate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func FuzzTruncate(f *testing.F) {
+	f.Add("test", 4, "…", uint8(0))
+	f.Fuzz(func(t *testing.T, str string, length int, omission string, posRaw uint8) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("Truncate should not panic with `%v`", r)
+			}
+		}()
+		pos := posRaw % 3
+		Truncate(str, length, omission, TruncatePosition(pos))
+	})
+}
+
 func BenchmarkTruncate(b *testing.B) {
 	benchmarks := []struct {
 		name     string


### PR DESCRIPTION
* Add boundary check when omission is shorter than the total length
* Add boundary check when negative target length is used
* Added fuzz test

Closes #4